### PR TITLE
Empezamos con los nombres de rama

### DIFF
--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -3,6 +3,7 @@ on:
   push:
     branches:
     - '*á*'
+    - '*é*'
 
 jobs:
   no_slash_in_branch_names:

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -2,7 +2,7 @@ name: Fail when incorrect branch names are used
 on:
   push:
     branches:
-    - '*[áéíóúÁÉÍÓÚñçÑÇ]*'
+    - '*[\u00E1\u00E9\u00ED\u00F3\u00FA]*'
 
 jobs:
   no_slash_in_branch_names:

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -7,17 +7,15 @@ on:
     - '*í*'
     - '*ó*'
     - '*ú*'
-
 jobs:
   no_slash_in_branch_names:
     runs-on: ubuntu-latest
     steps:
       - name: Si salta, debería fallar
         run: |
-          __msg="::error::Esta rama ${GITHUB_REF_NAME} tiene una vocal acentuada o letra como. Por favor, no la uses en nombres de rama.
+          __msg="::error title=NOmbre de rama incorrecto::Esta rama ${GITHUB_REF_NAME} tiene una vocal acentuada o letra como. Por favor, no la uses en nombres de rama.
           Cierra este PR y renombra la rama con
               git checkout ${GITHUB_REF_NAME}
               git branch -m <nuevo_nombre_sin_esas_letras>"
           echo "$__msg"
-          echo ::set-output name=status::failure
           exit 1

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -2,7 +2,7 @@ name: Fail when incorrect branch names are used
 on:
   push:
     branches:
-    - '*[\U00E1\U00E9\U00ED\U00F3\U00FA]*'
+    - '*á*'
 
 jobs:
   no_slash_in_branch_names:

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Si salta, debería fallar
         run: |
-          __msg="::error title=NOmbre de rama incorrecto::Esta rama ${GITHUB_REF_NAME} tiene una vocal acentuada o letra como. Por favor, no la uses en nombres de rama.
+          __msg="::error title=NOmbre de rama incorrecto::Esta rama ${GITHUB_REF_NAME} contiene una vocal acentuada. Por favor, no la uses en nombres de rama.
           Cierra este PR y renombra la rama con
               git checkout ${GITHUB_REF_NAME}
               git branch -m <nuevo_nombre_sin_esas_letras>"

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -1,0 +1,19 @@
+name: Fail when incorrect branch names are used
+on:
+  push:
+    branches:
+    - '*[áéíóúÁÉÍÓÚñçÑÇ]*
+
+jobs:
+  no_slash_in_branch_names:
+    runs-on: ubuntu-latest
+    steps:
+      - name: Si salta, debería fallar
+        run: |
+          __msg="::error::Esta rama ${GITHUB_REF_NAME} tiene una vocal acentuada o letra como ñ o ç. Por favor, no la uses en nombres de rama.
+          Cierra este PR y renombra la rama con
+              git checkout ${GITHUB_REF_NAME}
+              git branch -m <nuevo_nombre_sin_esas_letras>"
+          echo "$__msg"
+          echo ::set-output name=status::failure
+          exit 1

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -13,7 +13,7 @@ jobs:
     steps:
       - name: Si salta, debería fallar
         run: |
-          __msg="::error title=NOmbre de rama incorrecto::Esta rama ${GITHUB_REF_NAME} contiene una vocal acentuada. Por favor, no la uses en nombres de rama.
+          __msg="::error title=Nombre de rama incorrecto::Esta rama ${GITHUB_REF_NAME} contiene una vocal acentuada. Por favor, no la uses en nombres de rama.
           Cierra este PR y renombra la rama con
               git checkout ${GITHUB_REF_NAME}
               git branch -m <nuevo_nombre_sin_esas_letras>"

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -2,7 +2,7 @@ name: Fail when incorrect branch names are used
 on:
   push:
     branches:
-    - '*[\u00E1\u00E9\u00ED\u00F3\u00FA]*'
+    - '*[\\u00E1\\u00E9\\u00ED\\u00F3\\u00FA]*'
 
 jobs:
   no_slash_in_branch_names:

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -2,7 +2,7 @@ name: Fail when incorrect branch names are used
 on:
   push:
     branches:
-    - '*[áéíóúÁÉÍÓÚñçÑÇ]*
+    - '*[áéíóúÁÉÍÓÚñçÑÇ]*'
 
 jobs:
   no_slash_in_branch_names:

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -2,7 +2,7 @@ name: Fail when incorrect branch names are used
 on:
   push:
     branches:
-    - '*[\\u00E1\\u00E9\\u00ED\\u00F3\\u00FA]*'
+    - '*[\U00E1\U00E9\U00ED\U00F3\U00FA]*'
 
 jobs:
   no_slash_in_branch_names:

--- a/.github/workflows/branch-name-policy.yml
+++ b/.github/workflows/branch-name-policy.yml
@@ -4,6 +4,9 @@ on:
     branches:
     - '*á*'
     - '*é*'
+    - '*í*'
+    - '*ó*'
+    - '*ú*'
 
 jobs:
   no_slash_in_branch_names:
@@ -11,7 +14,7 @@ jobs:
     steps:
       - name: Si salta, debería fallar
         run: |
-          __msg="::error::Esta rama ${GITHUB_REF_NAME} tiene una vocal acentuada o letra como ñ o ç. Por favor, no la uses en nombres de rama.
+          __msg="::error::Esta rama ${GITHUB_REF_NAME} tiene una vocal acentuada o letra como. Por favor, no la uses en nombres de rama.
           Cierra este PR y renombra la rama con
               git checkout ${GITHUB_REF_NAME}
               git branch -m <nuevo_nombre_sin_esas_letras>"


### PR DESCRIPTION
Relacionado con #36, crea una github action específica para que falle si el nombre de rama sigue ese tipo de patrón.

> También es un ejemplo de un nombre de rama que igual habría que incluir en la política (o no, a mi me gustan esos nombres de rama)